### PR TITLE
Redirect to home page after sign up

### DIFF
--- a/lib/actions/auth.ts
+++ b/lib/actions/auth.ts
@@ -112,5 +112,5 @@ export async function signup(state: FormState, formData: FormData) {
       };
   }
 
-  redirect("/login");
+  redirect("/");
 }


### PR DESCRIPTION
This PR introduces changes to the sign up action
Previously, it redirects the newly signed up users to `/login`
Now, it redirects the user to the home page (`/`)